### PR TITLE
fix(ci): 依存のピン止め、pip-audit、Dependabot（Issue #2）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/update-plate-data.yml
+++ b/.github/workflows/update-plate-data.yml
@@ -35,7 +35,13 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install requests beautifulsoup4 pandas lxml html5lib
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Audit dependencies (pip-audit)
+      run: |
+        pip install pip-audit
+        pip-audit -r requirements.txt
 
     - name: Fetch and compare data using MediaWiki API
       id: check-data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+beautifulsoup4==4.14.3
+certifi==2026.2.25
+charset-normalizer==3.4.7
+html5lib==1.1
+idna==3.11
+lxml==6.1.0
+numpy==2.4.4
+pandas==3.0.2
+python-dateutil==2.9.0.post0
+requests==2.33.1
+six==1.17.0
+soupsieve==2.8.3
+typing_extensions==4.15.0
+urllib3==2.6.3
+webencodings==0.5.1


### PR DESCRIPTION
## 概要

[Issue #2](https://github.com/kyto64/number-plate-japan.csv/issues/2) の対応として、Python 依存関係の固定、CI での脆弱性監査、Dependabot による更新提案を追加しました。

## 変更内容

- **`requirements.txt`**: Python 3.11 環境で解決したバージョンを固定（`requests` / `pandas` / `lxml` / `html5lib` / `beautifulsoup4` および転送依存）
- **`.github/workflows/update-plate-data.yml`**: `pip install -r requirements.txt` に変更し、データ取得の前に `pip-audit -r requirements.txt` を実行
- **`.github/dependabot.yml`**: pip の週次更新 PR（最大 5 件）を有効化

## 確認

- Docker（`python:3.11-slim`）上で `pip install -r requirements.txt` 後に `python -m scripts.fetch_wiki_data` を実行し、取得・比較が完了することを確認済みです。

Fixes #2