### PR TITLE
ci: Actions の最小権限化とアクション SHA ピン留め（Issue #3）

### DIFF
--- a/.github/workflows/update-plate-data.yml
+++ b/.github/workflows/update-plate-data.yml
@@ -10,7 +10,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   update-data:
@@ -18,13 +17,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.11'
 
@@ -73,7 +72,7 @@ jobs:
 
     - name: Create Pull Request if changes detected
       if: steps.check-data.outputs.changes == 'true'
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "自動更新: ナンバープレート登録地名データの更新"


### PR DESCRIPTION
## 概要

[Issue #3](https://github.com/kyto64/number-plate-japan.csv/issues/3) に対応し、`GITHUB_TOKEN` の権限を必要最小限にし、第三者アクションをコミット SHA で固定しました。

## 変更内容

### 権限

- `issues: write` を削除（本ワークフローで Issue 操作はしていないため）
- 引き続き `contents: write` と `pull-requests: write` を保持（チェックアウト・コミット・プッシュ、および `create-pull-request` に必要）

### アクションのピン留め（2026-04-18 時点の各 `v4` / `v5` タグが指すコミット）

| アクション | SHA（短縮） |
|-----------|-------------|
| `actions/checkout` | `34e1148…`（タグ `v4` は現時点で `v4.3.1` と同一コミット） |
| `actions/setup-python` | `7f4fc3e…` |
| `peter-evans/create-pull-request` | `4e1beaa…` |

コメントで人間可読のタグ名を残しています。

Fixes #3